### PR TITLE
Add runbook about safely connecting to preprod

### DIFF
--- a/source/principles.html.md.erb
+++ b/source/principles.html.md.erb
@@ -7,6 +7,14 @@ review_in: 3 months
 
 # Principles
 
+## Operational restrictions
+
+- Do **not** access production data directly, except for emergencies.
+- **Never** run `psql` in a pod on _preprod_ or _prod_ namespaces.
+  All input and output are logged and can easily lead to a breach of personal data.
+
+Instead, rely on [port-forwarding from preprod](./runbooks/connect-to-preprod.html).
+
 
 ## Inherited principles
 

--- a/source/runbooks/connect-to-preprod.html.md.erb
+++ b/source/runbooks/connect-to-preprod.html.md.erb
@@ -15,6 +15,8 @@ Please see [operational restrictions](../principles.html#operational-restriction
 
 ### Actions
 
+<%= warning_text("Please read <a href=\"https://security-guidance.service.justice.gov.uk/data-handling-and-information-sharing-guide/#data-at-rest-on-moj-issued-laptops\">data at rest on MoJ-issued laptops</a> for guidance on storing sensitive data (query output).") %>
+
 Use the port forwarding script from [the operational scripts][ops-repo].
 
 ```

--- a/source/runbooks/connect-to-preprod.html.md.erb
+++ b/source/runbooks/connect-to-preprod.html.md.erb
@@ -13,6 +13,8 @@ We cannot use _production_ data directly, but we must observe the data.
 
 Please see [operational restrictions](../principles.html#operational-restrictions).
 
+Consider [refreshing preprod](./refresh-preprod.html) if you need more up-to-date data.
+
 ### Actions
 
 <%= warning_text("Please read <a href=\"https://security-guidance.service.justice.gov.uk/data-handling-and-information-sharing-guide/#data-at-rest-on-moj-issued-laptops\">data at rest on MoJ-issued laptops</a> for guidance on storing sensitive data (query output).") %>

--- a/source/runbooks/connect-to-preprod.html.md.erb
+++ b/source/runbooks/connect-to-preprod.html.md.erb
@@ -1,0 +1,50 @@
+---
+title: Connect to pre-production data
+weight: 40
+last_reviewed_on: 2022-09-07
+review_in: 1 year
+---
+
+# Connect to pre-production data
+
+### Problem
+
+We cannot use _production_ data directly, but we must observe the data.
+
+Please see [operational restrictions](../principles.html#operational-restrictions).
+
+### Actions
+
+Use the port forwarding script from [the operational scripts][ops-repo].
+
+```
+./setup_preprod_port_forward.sh
+```
+
+You should see:
+
+```
+{snip}
+Forwarding from 127.0.0.1:5433 -> 5432
+Forwarding from [::1]:5433 -> 5432
+```
+
+Then, you can connect locally:
+
+```
+psql -h localhost -p 5433 -U cpS00AbRsu dba326b0ca8eb97132
+```
+
+The password to use is in:
+
+```
+cloud-platform decode-secret \
+  --secret=postgres \
+  --namespace=hmpps-interventions-preprod
+```
+
+`cloud-platform` is the [Cloud Platform CLI tool][cli].
+
+
+[ops-repo]: https://github.com/ministryofjustice/hmpps-interventions-ops
+[cli]: https://github.com/ministryofjustice/cloud-platform-cli#install


### PR DESCRIPTION
## What does this pull request do?

Add runbook about safely connecting to the preprod environment.

## What is the intent behind these changes?

To consolidate the write-up of tasks that we use a lot in a single place.

## Screenshot

![image](https://user-images.githubusercontent.com/1526295/188865995-6c84e6e5-906c-403c-bbec-caa98925a6e0.png)
