### PR TITLE
Dynamically link to subpages on runbook main page

### DIFF
--- a/source/runbooks/index.html.md.erb
+++ b/source/runbooks/index.html.md.erb
@@ -8,3 +8,10 @@ review_in: 1 year
 # Runbooks and tasks
 
 Collection of typical tasks and recurring issues.
+
+<ul>
+  <% sitemap.resources.select { |resource| resource.path.start_with?("runbooks/") }.sort_by { |r| r.data.weight }.each do |resource| %>
+    <% next if resource.path == current_path %>
+    <li><%= link_to resource.data.title, resource, :relative => true %></li>
+  <% end %>
+</ul>


### PR DESCRIPTION
Makes navigation simpler for people

## What does this pull request do?

Dynamically link to subpages on the runbook main page

![image](https://user-images.githubusercontent.com/1526295/188873513-fc34b0b0-1949-480a-9d87-771fa3d3f585.png)

## What is the intent behind these changes?

Had no humour in maintaining the subpage list, so make it semi-automatic.