### PR TITLE
Document group access and wait for QuickSight

### DIFF
--- a/source/get-started/BI-dashboard-access.html.md
+++ b/source/get-started/BI-dashboard-access.html.md
@@ -23,7 +23,16 @@ The Modernisation Platform exposes these data points with [QuickSight](https://a
    with the "Request to join" button in the top right corner.
 1. Ask the team in the [#interventions-dev] Slack channel to approve the team join request.
 
+
+### Wait for your membership to copy across
+
 After joining the GitHub team, it may take up to **six hours** for access to propagate to the Modernisation Platform.
+
+If the sync did not yet happen, you will see:
+
+![SSO sync not happened](../images/modplatform-sso-sync-not-happened.png)
+
+If this happens, please try again in a few hours.
 
 If you need immediate access, please [#ask-operations-engineering] to manually run the SSO Sync job, referring to this guide
 and [this definition](https://github.com/ministryofjustice/modernisation-platform/blob/4b7becb4a7162fd59039b9e1c1d65b9d2d1e79e8/environments/refer-monitor.json#L12).

--- a/source/get-started/BI-dashboard-access.html.md
+++ b/source/get-started/BI-dashboard-access.html.md
@@ -35,9 +35,17 @@ and [this definition](https://github.com/ministryofjustice/modernisation-platfor
 1. Log in with GitHub.
 1. Open the "Management console" button on the `refer-monitor-development` namespace with `modernisation-platform-sandbox` credentials:
    ![Management console button](../images/modplatform-console.png)
-1. Once in, search for "quicksight":
-   ![Search for QuickSight](../images/modplatform-search-quicksight.png)
-1. After opening it, you should see a page with "Analyses" selected that might look like this:
+1. Check you see the "AWS console" main page:
+   ![AWS console main page](../images/modplatform-console-main-page.png)
+1. Add yourself to the _refer-monitor-team_ group [here](https://quicksight.aws.amazon.com/sn/console/groups):
+   ![Add yourself to the group](../images/modplatform-quicksight-group-add.png)
+1. Verify access by opening [the shared folders](https://quicksight.aws.amazon.com/sn/folders/public). You must see at least one:
+   ![Shared folders](../images/modplatform-quicksight-shared-folders.png)
+
+
+### Testing access
+
+1. After adding yourself, go to [QuickSight analyses](https://quicksight.aws.amazon.com/sn/start/analyses). You should see a page like this:
    ![QuickSight start page](../images/modplatform-quicksight-landing-page.png)
 1. Open one of the "Analyses", and you should see something similar:
    ![Sample analysis](../images/modplatform-quicksight-sample-analysis.png)

--- a/source/images/modplatform-console-main-page.png
+++ b/source/images/modplatform-console-main-page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e891177f22c76bda6b1ea6b722a28d339ab9431d12a708f1da3088885536cf09
+size 346073

--- a/source/images/modplatform-quicksight-group-add.png
+++ b/source/images/modplatform-quicksight-group-add.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2e1efd820c20fa56071b82139070adcd283cdec97fd4bfe4cd5f307fd43518f
+size 205002

--- a/source/images/modplatform-quicksight-shared-folders.png
+++ b/source/images/modplatform-quicksight-shared-folders.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a61a85680be90360fd484f19376772064aec9a2ed0c98f049a8a25a40be488ec
+size 117899

--- a/source/images/modplatform-sso-sync-not-happened.png
+++ b/source/images/modplatform-sso-sync-not-happened.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dd91684d5d6f11c958c0aa483c05408347b1c0ff6381df8a19ff67899b56e4c
+size 83649


### PR DESCRIPTION
## What does this pull request do?

[Document how to get access to shared resources](https://github.com/ministryofjustice/hmpps-interventions-docs/commit/673678e68358cd4d845fa7b040665e35299d7076)
  
[Add "wait up to six hours" guidance](https://github.com/ministryofjustice/hmpps-interventions-docs/commit/2d82bea55bf29b55d39a9ced353151eca6a65d14)

## What is the intent behind these changes?

Better guidance. Perhaps this should be in Confluence?