### PR TITLE
Update like to GitHub Access guidance

### DIFF
--- a/source/get-started.html.md.erb
+++ b/source/get-started.html.md.erb
@@ -1,13 +1,13 @@
 ---
 title: Get started
 weight: 20
-last_reviewed_on: 2024-06-06
+last_reviewed_on: 2024-12-09
 review_in: 3 months
 ---
 
 # Get started
 
-You will need a [GitHub account with Ministry of Justice organisation access](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#github-access).
+You will need a [GitHub account with Ministry of Justice organisation access](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#github-access).
 
 Afterwards, please request to join the [@ministryofjustice/hmpps-interventions-dev](https://github.com/orgs/ministryofjustice/teams/hmpps-interventions-dev) GitHub team.
 


### PR DESCRIPTION
## What does this pull request do?

This PR updates the link to GitHub access guidance that has been relocated to the Operations Engineering User Guide.

## What is the intent behind these changes?

Keeps links up to date.