### PR TITLE
Update link to legacy Operations Engineerig Guidance

### DIFF
--- a/source/get-started.html.md.erb
+++ b/source/get-started.html.md.erb
@@ -7,7 +7,7 @@ review_in: 3 months
 
 # Get started
 
-You will need a [GitHub account with Ministry of Justice organisation access](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#github-access).
+You will need a [GitHub account with Ministry of Justice organisation access](https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/operations-engineering-legacy/operations-engineering-user-guide/github/storing-source-code.html#github-access).
 
 Afterwards, please request to join the [@ministryofjustice/hmpps-interventions-dev](https://github.com/orgs/ministryofjustice/teams/hmpps-interventions-dev) GitHub team.
 


### PR DESCRIPTION
## What does this pull request do?

This PR updates the link to legacy Operations Engineering guidance

## What is the intent behind these changes?

Ensures that guidance is still available when Ops Eng guide is decommissioned.
